### PR TITLE
Add firebase and config.json to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Before you can run this application, you will need to install `Node.js` on your 
 The data-marketplace uses [Firebase](https://firebase.google.com/) as storage solution. 
 You need an active Firebase project to use the data-marketplace. Please create one.
 
-### Add config.json in src/
+### change config.json.example
 
-There is an example config.json file in the src directory. Create a config.json file with the same structure.
-You can get the information in the Firebase getting started guide for your project.
+There is a json example in the src directory. Rename the config.json.example to config.json. 
+Replace all values with the values from your Firebase project.
+You can get get the information by the Firebase getting started guide in your project.
 
 ### Enable Google Authentication
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ The Proof of Concept Data Marketplace built using MAM and IOTA Tangle.
 
 Before you can run this application, you will need to install `Node.js` on your machine. Once you've installed `Node.js`, you can use `npm` to run commands listed below.
 
+### Create a Firebase Account
+
+The data-marketplace uses [Firebase](https://firebase.google.com/) as storage solution. 
+You need an active Firebase project to use the data-marketplace. Please create one.
+
+### Add config.json in src/
+
+There is an example config.json file in the src directory. Create a config.json file with the same structure.
+You can get the information in the Firebase getting started guide for your project.
+
 ### To run for Development.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Before you can run this application, you will need to install `Node.js` on your 
 ### Create a Firebase Account
 
 The data-marketplace uses [Firebase](https://firebase.google.com/) as storage solution. 
-You need an active Firebase project to use the data-marketplace. Please create one.
+You need an active Firebase project to use the data-marketplace.
 
 ### change config.json.example
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ You need an active Firebase project to use the data-marketplace. Please create o
 There is an example config.json file in the src directory. Create a config.json file with the same structure.
 You can get the information in the Firebase getting started guide for your project.
 
+### Enable Google Authentication
+
+You need to enable Google Authentication in your Firebase project.
+
 ### To run for Development.
 
 ```javascript


### PR DESCRIPTION
You need an active Firebase account to be able to run the data-marketplace. This adds it to the readme.