### PR TITLE
fix: Remove bias from key generator

### DIFF
--- a/public/static/template/iota.js
+++ b/public/static/template/iota.js
@@ -10,8 +10,14 @@ let mamState = Mam.init(provider);
 // Random Key Generator
 const generateRandomKey = length => {
   const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ9';
-  const values = crypto.randomBytes(length);
-  return Array.from(new Array(length), (x, i) => charset[values[i] % charset.length]).join('');
+  let key = '';
+  while (key.length < length) {
+    const byte = crypto.randomBytes(1);
+    if (byte[0] < 243) {
+        key += charset.charAt(byte[0] % 27);
+    }
+  }
+  return key;
 };
 
 // Publish to Tangle


### PR DESCRIPTION
The current implementation of the key generator is biased towards the first 13 letters of the tryte charset since 256 cannot be divided evenly by 27 (see https://github.com/iotaledger/mam.client.js/issues/12 for more info). This PR ensures a uniform distribution by discarding any bytes with values 243-255.

Fixes #55 